### PR TITLE
Paginator constructors should be public to use outside the library

### DIFF
--- a/src/main/java/net/dean/jraw/paginators/AllSubredditsPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/AllSubredditsPaginator.java
@@ -18,7 +18,7 @@ public class AllSubredditsPaginator extends GenericPaginator<Subreddit> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param where The criteria in which to return Subreddits
      */
-    AllSubredditsPaginator(RedditClient creator, String where) {
+    public AllSubredditsPaginator(RedditClient creator, String where) {
         super(creator, Subreddit.class, where);
     }
 

--- a/src/main/java/net/dean/jraw/paginators/CompoundSubredditPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/CompoundSubredditPaginator.java
@@ -17,7 +17,7 @@ public class CompoundSubredditPaginator extends SubredditPaginator {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param subreddits The subreddits to iterate over. Must contain at least on element.
      */
-    CompoundSubredditPaginator(RedditClient creator, List<String> subreddits) {
+    public CompoundSubredditPaginator(RedditClient creator, List<String> subreddits) {
         super(creator);
         setSubreddits(subreddits);
         this.subreddits = Collections.unmodifiableList(subreddits);

--- a/src/main/java/net/dean/jraw/paginators/ImportantUserPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/ImportantUserPaginator.java
@@ -17,7 +17,7 @@ public class ImportantUserPaginator extends GenericUserRecordPaginator {
      * @param creator The RedditClient that will be used to send requests
      * @param where   What to look up
      */
-    ImportantUserPaginator(RedditClient creator, String where) {
+    public ImportantUserPaginator(RedditClient creator, String where) {
         super(creator, where);
     }
 

--- a/src/main/java/net/dean/jraw/paginators/InboxPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/InboxPaginator.java
@@ -17,7 +17,7 @@ public class InboxPaginator extends GenericPaginator<Message> {
      * @param reddit The client to send requests with
      * @param where  The "where" enum value to use
      */
-    InboxPaginator(RedditClient reddit, String where) {
+    public InboxPaginator(RedditClient reddit, String where) {
         super(reddit, Message.class, where);
     }
 

--- a/src/main/java/net/dean/jraw/paginators/LiveThreadPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/LiveThreadPaginator.java
@@ -21,7 +21,7 @@ public class LiveThreadPaginator extends Paginator<LiveUpdate> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param threadId The live thread's ID
      */
-    LiveThreadPaginator(RedditClient creator, String threadId) {
+    public LiveThreadPaginator(RedditClient creator, String threadId) {
         super(creator, LiveUpdate.class);
         this.threadId = threadId;
     }

--- a/src/main/java/net/dean/jraw/paginators/ModeratorPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/ModeratorPaginator.java
@@ -25,7 +25,7 @@ public class ModeratorPaginator extends GenericPaginator<PublicContribution> {
      * @param subreddit The subreddit to view. Must be a moderator.
      * @param where What to paginate
      */
-    ModeratorPaginator(RedditClient creator, String subreddit, String where) {
+    public ModeratorPaginator(RedditClient creator, String subreddit, String where) {
         super(creator, PublicContribution.class, where);
         this.subreddit = subreddit;
     }

--- a/src/main/java/net/dean/jraw/paginators/MultiHubPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/MultiHubPaginator.java
@@ -37,7 +37,7 @@ public class MultiHubPaginator extends Paginator<MultiHubPaginator.MultiRedditId
      * Instantiates a new MultiHubPaginator
      * @param client The RedditClient to use
      */
-    MultiHubPaginator(RedditClient client) {
+    public MultiHubPaginator(RedditClient client) {
         super(client, MultiRedditId.class);
         // Blank matcher for now, reset(String) will be called later
         this.matcher = Pattern.compile(MULTIREDDIT_URL_REGEX).matcher("");

--- a/src/main/java/net/dean/jraw/paginators/MultiRedditPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/MultiRedditPaginator.java
@@ -16,7 +16,7 @@ public class MultiRedditPaginator extends Paginator<Submission> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param multi The multireddit to iterate
      */
-    MultiRedditPaginator(RedditClient creator, MultiReddit multi) {
+    public MultiRedditPaginator(RedditClient creator, MultiReddit multi) {
         super(creator, Submission.class);
         this.multiReddit = multi;
     }

--- a/src/main/java/net/dean/jraw/paginators/SpecificPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/SpecificPaginator.java
@@ -21,7 +21,7 @@ public class SpecificPaginator extends Paginator<Submission> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param submissionFullNames A list of fullnames of Submissions
      */
-    SpecificPaginator(RedditClient creator, String... submissionFullNames) {
+    public SpecificPaginator(RedditClient creator, String... submissionFullNames) {
         super(creator, Submission.class);
         setSubmissions(submissionFullNames);
     }

--- a/src/main/java/net/dean/jraw/paginators/SubmissionSearchPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/SubmissionSearchPaginator.java
@@ -27,7 +27,7 @@ public class SubmissionSearchPaginator extends Paginator<Submission> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param query   What to search for
      */
-    SubmissionSearchPaginator(RedditClient creator, String query) {
+    public SubmissionSearchPaginator(RedditClient creator, String query) {
         super(creator, Submission.class);
         this.query = query;
         this.sorting = DEFAULT_SORTING;

--- a/src/main/java/net/dean/jraw/paginators/SubredditPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/SubredditPaginator.java
@@ -18,7 +18,7 @@ public class SubredditPaginator extends Paginator<Submission> {
      * Instantiates a new SubredditPaginator
      * @param creator The RedditClient that will be used to send HTTP requests
      */
-    SubredditPaginator(RedditClient creator) {
+    public SubredditPaginator(RedditClient creator) {
         super(creator, Submission.class);
     }
     

--- a/src/main/java/net/dean/jraw/paginators/SubredditSearchPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/SubredditSearchPaginator.java
@@ -22,7 +22,7 @@ public class SubredditSearchPaginator extends Paginator<Subreddit> {
      * @param creator The RedditClient that will be used to send HTTP requests
      * @param query   What to search for
      */
-    SubredditSearchPaginator(RedditClient creator, String query) {
+    public SubredditSearchPaginator(RedditClient creator, String query) {
         super(creator, Subreddit.class);
         this.query = query;
     }

--- a/src/main/java/net/dean/jraw/paginators/UserContributionPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/UserContributionPaginator.java
@@ -19,7 +19,7 @@ public class UserContributionPaginator extends GenericPaginator<Contribution> {
      * @param where The criteria in which to return Subreddits
      * @param username The user to view
      */
-    UserContributionPaginator(RedditClient creator, String where, String username) {
+    public UserContributionPaginator(RedditClient creator, String where, String username) {
         super(creator, Contribution.class, where);
         this.username = username;
     }

--- a/src/main/java/net/dean/jraw/paginators/UserRecordPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/UserRecordPaginator.java
@@ -21,7 +21,7 @@ public class UserRecordPaginator extends GenericUserRecordPaginator {
      *                  subreddit.
      * @param where What to iterate
      */
-    UserRecordPaginator(RedditClient creator, String subreddit, String where) {
+    public UserRecordPaginator(RedditClient creator, String subreddit, String where) {
         super(creator, where);
         this.subreddit = subreddit;
     }

--- a/src/main/java/net/dean/jraw/paginators/UserSubredditsPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/UserSubredditsPaginator.java
@@ -19,7 +19,7 @@ public class UserSubredditsPaginator extends GenericPaginator<Subreddit> {
      * @param client The RedditClient that will be used to send HTTP requests
      * @param where The criteria in which to return Subreddits
      */
-    UserSubredditsPaginator(RedditClient client, String where) {
+    public UserSubredditsPaginator(RedditClient client, String where) {
         super(client, Subreddit.class, where);
     }
 


### PR DESCRIPTION
The compiler complains when attempting to use each constructor under a
new package that is not the same as the library.

Signed-off-by: Fernando Barillas fbis251@mailbox.org
