### PR TITLE
Add Streams, fixes #206

### DIFF
--- a/lib/src/main/java/net/dean/jraw/models/Account.java
+++ b/lib/src/main/java/net/dean/jraw/models/Account.java
@@ -17,7 +17,7 @@ import java.util.Date;
 
 @AutoValue
 @RedditModel
-public abstract class Account implements Created, Referenceable<UserReference<?>>, Serializable {
+public abstract class Account implements Created, Referenceable<UserReference<?>>, Serializable, UniquelyIdentifiable {
     /** The amount of Karma this user has acquired through comment */
     @Json(name = "comment_karma") public abstract int getCommentKarma();
 
@@ -48,6 +48,9 @@ public abstract class Account implements Created, Referenceable<UserReference<?>
     @Json(name = "name") public abstract String getName();
 
     // TODO: a lot more properties for logged-in users (see /api/v1/me)
+
+    @NotNull
+    @Override public String getUniqueId() { return getName(); }
 
     @NotNull
     @Override

--- a/lib/src/main/java/net/dean/jraw/models/Comment.java
+++ b/lib/src/main/java/net/dean/jraw/models/Comment.java
@@ -88,6 +88,9 @@ public abstract class Comment implements PublicContribution<CommentReference>, N
     @Json(name = "score_hidden") public abstract boolean isScoreHidden();
 
     @NotNull
+    @Override public String getUniqueId() { return getFullName(); }
+
+    @NotNull
     @Override
     @Json(name = "likes") public abstract VoteDirection getVote();
 

--- a/lib/src/main/java/net/dean/jraw/models/LiveThread.java
+++ b/lib/src/main/java/net/dean/jraw/models/LiveThread.java
@@ -52,6 +52,10 @@ public abstract class LiveThread implements Created, Identifiable, Referenceable
 
     @NotNull
     @Override
+    public String getUniqueId() { return getFullName(); }
+
+    @NotNull
+    @Override
     public LiveThreadReference toReference(@NotNull RedditClient reddit) {
         return reddit.liveThread(getId());
     }

--- a/lib/src/main/java/net/dean/jraw/models/LiveUpdate.java
+++ b/lib/src/main/java/net/dean/jraw/models/LiveUpdate.java
@@ -33,6 +33,10 @@ public abstract class LiveUpdate implements Created, Identifiable, Serializable 
      */
     public abstract boolean isStricken();
 
+    @NotNull
+    @Override
+    public String getUniqueId() { return getFullName(); }
+
     public static JsonAdapter<LiveUpdate> jsonAdapter(Moshi moshi) {
         return new AutoValue_LiveUpdate.MoshiJsonAdapter(moshi);
     }

--- a/lib/src/main/java/net/dean/jraw/models/Message.java
+++ b/lib/src/main/java/net/dean/jraw/models/Message.java
@@ -58,6 +58,10 @@ public abstract class Message implements Created, Distinguishable, Identifiable,
     /** The subject line of the private message, or the string "`comment reply`" for comments. */
     public abstract String getSubject();
 
+    @NotNull
+    @Override
+    public String getUniqueId() { return getFullName(); }
+
     /**
      * The name of the subreddit where this comment or username mention was created, or null if this message isn't a
      * comment or username mention

--- a/lib/src/main/java/net/dean/jraw/models/MoreChildren.java
+++ b/lib/src/main/java/net/dean/jraw/models/MoreChildren.java
@@ -35,6 +35,9 @@ public abstract class MoreChildren implements NestedIdentifiable, Serializable {
 
     @Json(name = "children") public abstract List<String> getChildrenIds();
 
+    @NotNull
+    @Override public String getUniqueId() { return getFullName(); }
+
     /**
      * Returns true if this MoreChildren object represents a thread continuation. On the website, thread continuations
      * are illustrated with "continue this thread →". Thread continuations are only seen when the depth of a CommentNode

--- a/lib/src/main/java/net/dean/jraw/models/SimpleFlairInfo.java
+++ b/lib/src/main/java/net/dean/jraw/models/SimpleFlairInfo.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
@@ -19,7 +20,7 @@ import java.util.List;
  * @see <a href="https://www.reddit.com/dev/api/#POST_api_flaircsv">Reddit API - POST /api/flaircsv</a>
  */
 @AutoValue
-public abstract class SimpleFlairInfo implements Serializable {
+public abstract class SimpleFlairInfo implements Serializable, UniquelyIdentifiable {
 
     /** Username */
     public abstract String getUser();
@@ -31,6 +32,12 @@ public abstract class SimpleFlairInfo implements Serializable {
     /** Text displayed on the flair, if any */
     @Nullable
     @Json(name = "flair_text") public abstract String getText();
+
+    @NotNull
+    @Override
+    public String getUniqueId() {
+        return String.valueOf(hashCode());
+    }
 
     /**
      * Convert this object into a single line in a CSV line used for setting user flairs in bulk.

--- a/lib/src/main/java/net/dean/jraw/models/Submission.java
+++ b/lib/src/main/java/net/dean/jraw/models/Submission.java
@@ -134,6 +134,9 @@ public abstract class Submission implements PublicContribution<SubmissionReferen
     /** Title of the submission */
     public abstract String getTitle();
 
+    @NotNull
+    @Override public String getUniqueId() { return getFullName(); }
+
     /** An absolute URL to the comments for a self post, otherwise an absolute URL to the Submission content */
     public abstract String getUrl();
 

--- a/lib/src/main/java/net/dean/jraw/models/Subreddit.java
+++ b/lib/src/main/java/net/dean/jraw/models/Subreddit.java
@@ -138,6 +138,10 @@ public abstract class Subreddit implements Created, Identifiable, Referenceable<
     /** The title of the tab when visiting this subreddit on a web browser */
     public abstract String getTitle();
 
+    @NotNull
+    @Override
+    public String getUniqueId() { return getFullName(); }
+
     /** The URL to access this subreddit relative to reddit.com. For example, "/r/pics" */
     public abstract String getUrl();
 

--- a/lib/src/main/java/net/dean/jraw/models/Trophy.java
+++ b/lib/src/main/java/net/dean/jraw/models/Trophy.java
@@ -40,6 +40,10 @@ public abstract class Trophy implements Identifiable, Serializable {
     /** The 70x70 icon for this Trophy */
     @Json(name = "icon_70") public abstract String getIcon70();
 
+    @NotNull
+    @Override
+    public String getUniqueId() { return getFullName(); }
+
     public static JsonAdapter<Trophy> jsonAdapter(Moshi moshi) {
         return new AutoValue_Trophy.MoshiJsonAdapter(moshi);
     }

--- a/lib/src/main/java/net/dean/jraw/models/WikiRevision.java
+++ b/lib/src/main/java/net/dean/jraw/models/WikiRevision.java
@@ -6,6 +6,7 @@ import com.squareup.moshi.Moshi;
 import net.dean.jraw.databind.Enveloped;
 import net.dean.jraw.databind.RedditModel;
 import net.dean.jraw.databind.UnixTime;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
@@ -13,12 +14,18 @@ import java.util.Date;
 
 @AutoValue
 @RedditModel(enveloped = false)
-public abstract class WikiRevision implements Serializable {
+public abstract class WikiRevision implements Serializable, UniquelyIdentifiable {
     @UnixTime public abstract Date getTimestamp();
     @Nullable public abstract String getReason();
     @Nullable @Enveloped public abstract Account getAuthor();
     public abstract String getPage();
     public abstract String getId();
+
+    @NotNull
+    @Override
+    public String getUniqueId() {
+        return String.valueOf(hashCode());
+    }
 
     public static WikiRevision create(Date newTimestamp, String newReason, Account newAuthor, String newPage, String newId) {
         return new AutoValue_WikiRevision(newTimestamp, newReason, newAuthor, newPage, newId);

--- a/lib/src/main/kotlin/net/dean/jraw/Experimental.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/Experimental.kt
@@ -1,0 +1,5 @@
+package net.dean.jraw
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Experimental

--- a/lib/src/main/kotlin/net/dean/jraw/models/Identifiable.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/models/Identifiable.kt
@@ -1,11 +1,7 @@
 package net.dean.jraw.models
 
 /** A model is identifiable if it has a full name (like "t1_abc123") and an ID (like "abc123") */
-interface Identifiable {
-    /**
-     * The full name of the model. Essentially equivalent to joining the kind prefix (e.g. "t1" for comments) with
-     * [id]. For example, a comment with an ID of "abc123" would have a full name of "t1_abc123"
-     */
+interface Identifiable : UniquelyIdentifiable {
     val fullName: String
 
     /** The unique base 36 identifier given to this model by reddit */

--- a/lib/src/main/kotlin/net/dean/jraw/models/UniquelyIdentifiable.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/models/UniquelyIdentifiable.kt
@@ -1,0 +1,6 @@
+package net.dean.jraw.models
+
+/** Exists solely for the purpose of [net.dean.jraw.pagination.Stream] */
+interface UniquelyIdentifiable {
+    val uniqueId: String
+}

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/BackoffStrategy.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/BackoffStrategy.kt
@@ -1,0 +1,14 @@
+package net.dean.jraw.pagination
+
+import net.dean.jraw.Experimental
+
+@Experimental
+interface BackoffStrategy {
+    /**
+     * Returns the amount of milliseconds until the next request should be made.
+     *
+     * @param newItems The number of new items present in the existing response
+     * @param totalItems The total number of items received in the response
+     */
+    fun delayRequest(newItems: Int, totalItems: Int): Long
+}

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/BarebonesPaginator.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/BarebonesPaginator.kt
@@ -2,12 +2,13 @@ package net.dean.jraw.pagination
 
 import net.dean.jraw.RedditClient
 import net.dean.jraw.http.HttpRequest
+import net.dean.jraw.models.UniquelyIdentifiable
 
 /**
  * This class, like its name suggests, supports fewer query modifiers compared to other Paginators. Only the limit can
  * be set.
  */
-open class BarebonesPaginator<T> private constructor(
+open class BarebonesPaginator<T : UniquelyIdentifiable> private constructor(
     reddit: RedditClient,
     baseUrl: String,
     limit: Int,
@@ -25,7 +26,7 @@ open class BarebonesPaginator<T> private constructor(
     }
 
     /** Builder pattern for this class */
-    class Builder<T>(reddit: RedditClient, baseUrl: String, clazz: Class<T>) :
+    class Builder<T : UniquelyIdentifiable>(reddit: RedditClient, baseUrl: String, clazz: Class<T>) :
         Paginator.Builder<T>(reddit, baseUrl, clazz) {
 
         /** How many items to request at once */
@@ -40,7 +41,7 @@ open class BarebonesPaginator<T> private constructor(
         /** */
         companion object {
             /** Convenience factory function using reified generics */
-            inline fun <reified T> create(reddit: RedditClient, baseUrl: String): Builder<T> {
+            inline fun <reified T : UniquelyIdentifiable> create(reddit: RedditClient, baseUrl: String): Builder<T> {
                 return Builder(reddit, baseUrl, T::class.java)
             }
         }

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/ConstantBackoffStrategy.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/ConstantBackoffStrategy.kt
@@ -1,0 +1,12 @@
+package net.dean.jraw.pagination
+
+/**
+ * A ConstantBackoffStrategy is probably a misnomer because this class never "backs off," but instead continues to make
+ * requests at a constant rate regardless of how many new items were discovered.
+ *
+ * @param millis The amount of milliseconds to wait between each request. Defaults to 1000 (1 second). Note that
+ * the RedditClient's rate limiting will overpower if it comes to that.
+ */
+class ConstantBackoffStrategy(val millis: Long = 1000L) : BackoffStrategy {
+    override fun delayRequest(newItems: Int, totalItems: Int): Long = millis
+}

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/DefaultPaginator.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/DefaultPaginator.kt
@@ -4,13 +4,14 @@ import net.dean.jraw.RedditClient
 import net.dean.jraw.http.HttpRequest
 import net.dean.jraw.models.Sorting
 import net.dean.jraw.models.TimePeriod
+import net.dean.jraw.models.UniquelyIdentifiable
 import net.dean.jraw.pagination.DefaultPaginator.Builder
 
 /**
  * This Paginator is for paginated API endpoints that support not only limits, but sortings and time periods
  * (e.g. /top).
  */
-open class DefaultPaginator<T> protected constructor(
+open class DefaultPaginator<T : UniquelyIdentifiable> protected constructor(
     reddit: RedditClient,
     baseUrl: String,
 
@@ -47,7 +48,7 @@ open class DefaultPaginator<T> protected constructor(
     }
 
     /** Builder pattern for this class */
-    open class Builder<T, S : Sorting>(
+    open class Builder<T : UniquelyIdentifiable, S : Sorting>(
         reddit: RedditClient,
         baseUrl: String,
 
@@ -77,7 +78,11 @@ open class DefaultPaginator<T> protected constructor(
         /** */
         companion object {
             /** Convenience factory function using reified generics */
-            inline fun <reified T, S : Sorting> create(reddit: RedditClient, baseUrl: String, sortingAlsoInPath: Boolean = false): Builder<T, S> {
+            inline fun <reified T : UniquelyIdentifiable, S : Sorting> create(
+                reddit: RedditClient,
+                baseUrl: String,
+                sortingAlsoInPath: Boolean = false
+            ): Builder<T, S> {
                 return Builder(reddit, baseUrl, sortingAlsoInPath, T::class.java)
             }
         }

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/Paginator.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/Paginator.kt
@@ -94,8 +94,6 @@ abstract class Paginator<T : UniquelyIdentifiable> protected constructor(
 
     override fun accumulateMerged(maxPages: Int): List<T> = accumulate(maxPages).flatten()
 
-    override fun stream(backoff: BackoffStrategy): Stream<T> = Stream(this, backoff)
-
     /** Creates an HTTP request to fetch the next page of data, if any. */
     protected abstract fun createNextRequest(): HttpRequest.Builder
 

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/Paginator.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/Paginator.kt
@@ -6,17 +6,14 @@ import net.dean.jraw.JrawUtils
 import net.dean.jraw.RedditClient
 import net.dean.jraw.databind.Enveloped
 import net.dean.jraw.http.HttpRequest
-import net.dean.jraw.models.GeneralSort
-import net.dean.jraw.models.Listing
-import net.dean.jraw.models.Sorting
-import net.dean.jraw.models.TimePeriod
+import net.dean.jraw.models.*
 import net.dean.jraw.pagination.Paginator.Companion.RECOMMENDED_MAX_LIMIT
 
 /**
  * A Paginator is used to iterate over API endpoints that return a Listing. Paginator uses the builder pattern and once
  * built, its settings cannot be modified.
  */
-abstract class Paginator<T> protected constructor(
+abstract class Paginator<T : UniquelyIdentifiable> protected constructor(
     /** The client to use to request data */
     val reddit: RedditClient,
 
@@ -97,13 +94,15 @@ abstract class Paginator<T> protected constructor(
 
     override fun accumulateMerged(maxPages: Int): List<T> = accumulate(maxPages).flatten()
 
+    override fun stream(backoff: BackoffStrategy): Stream<T> = Stream(this, backoff)
+
     /** Creates an HTTP request to fetch the next page of data, if any. */
-    abstract protected fun createNextRequest(): HttpRequest.Builder
+    protected abstract fun createNextRequest(): HttpRequest.Builder
 
     /**
      * Base for all Paginator.Builder subclasses
      */
-    abstract class Builder<T>(
+    abstract class Builder<T : UniquelyIdentifiable>(
         /** The RedditClient used to send requests */
         val reddit: RedditClient,
 

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/RedditIterable.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/RedditIterable.kt
@@ -1,11 +1,12 @@
 package net.dean.jraw.pagination
 
 import net.dean.jraw.models.Listing
+import net.dean.jraw.models.UniquelyIdentifiable
 
 /**
  * A standard interface for interacting with paginated data provided by the reddit API.
  */
-interface RedditIterable<T> : Iterable<Listing<T>> {
+interface RedditIterable<T : UniquelyIdentifiable> : Iterable<Listing<T>> {
     /** The most recently fetched Listing, or null if no work has been done yet. */
     val current: Listing<T>?
 
@@ -33,4 +34,10 @@ interface RedditIterable<T> : Iterable<Listing<T>> {
 
     /** Does the same thing as [accumulate], but merges all Listing children into one List */
     fun accumulateMerged(maxPages: Int): List<T>
+
+    /** Returns a Stream for this data using a [ConstantBackoffStrategy] using the default settings */
+    fun stream() = stream(ConstantBackoffStrategy())
+
+    /** Returns a Stream for this data */
+    fun stream(backoff: BackoffStrategy): Stream<T>
 }

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/RedditIterable.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/RedditIterable.kt
@@ -39,5 +39,5 @@ interface RedditIterable<T : UniquelyIdentifiable> : Iterable<Listing<T>> {
     fun stream() = stream(ConstantBackoffStrategy())
 
     /** Returns a Stream for this data */
-    fun stream(backoff: BackoffStrategy): Stream<T>
+    fun stream(backoff: BackoffStrategy): Stream<T> = Stream(this, backoff)
 }

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/RotatingSearchList.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/RotatingSearchList.kt
@@ -1,0 +1,59 @@
+package net.dean.jraw.pagination
+
+/**
+ * This class is a very simple data structure which functions similarly to a LRU cache with no max age, but with a fixed
+ * size. Until capacity is reached, adding new data functions exactly like a normal list. However, once the capacity has
+ * been reached, new data is added at index 0, then to 1, 2, etc, overwriting older data.
+ *
+ * @param capacity The maximum number of elements to store
+ */
+internal class RotatingSearchList<T>(val capacity: Int) {
+    // All are internal for testing purposes only
+    internal val backingArray: Array<Any?> = arrayOfNulls(capacity)
+    internal var currentIndex = 0
+    private var _size = 0
+
+    /** The amount of elements currently being stored */
+    val size: Int
+        get() = _size
+
+    /**
+     * Adds some data. Returns whatever data was overwritten by this call.
+     */
+    fun add(data: T): T? {
+        @Suppress("UNCHECKED_CAST")
+        val overwrittenData: T? = backingArray[currentIndex] as T?
+
+        backingArray[currentIndex] = data
+
+        if (++currentIndex >= backingArray.size)
+            currentIndex = 0
+
+        // If we haven't overwritten anything, then we've added new data
+        if (overwrittenData == null)
+            _size++
+
+        return overwrittenData
+    }
+
+    /**
+     * Checks if some data is currently being stored. This function assumes the data is likely to have been inserted
+     * recently
+     */
+    fun contains(data: T): Boolean {
+        // Start at currentIndex because in our case it's more likely that the data we're looking for (if it's in here)
+        // is going to be added more recently
+        for (i in 0 until size) {
+            // We have to add backingArray.size here because Java does not do the mod operation properly (at least
+            // according to the mathematical definition of mod). In Python: -1 % 5 --> 4. In Java: -1 % 5 --> -1. We
+            // want the Python result, and to ensure that, we have to add backingArray.size (5 in the previous example).
+            // (-1 + 5) % 5 --> 4 in both languages.
+            val index = (currentIndex - 1 - i + backingArray.size) % backingArray.size
+            if (backingArray[index] == data) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/lib/src/main/kotlin/net/dean/jraw/pagination/Stream.kt
+++ b/lib/src/main/kotlin/net/dean/jraw/pagination/Stream.kt
@@ -1,0 +1,63 @@
+package net.dean.jraw.pagination
+
+import net.dean.jraw.Experimental
+import net.dean.jraw.models.UniquelyIdentifiable
+
+/**
+ * A Stream is special Iterator subclass that polls from a given source (usually a [Paginator]), and yields new data as
+ * each item becomes available.
+ *
+ * Consider [next] to be a blocking operation if this Stream is given a data source that interacts with the network.
+ */
+@Experimental
+class Stream<out T : UniquelyIdentifiable> @JvmOverloads constructor(
+    private val dataSource: RedditIterable<T>,
+    private val backoff: BackoffStrategy = ConstantBackoffStrategy(),
+    historySize: Int = 500
+) : Iterator<T> {
+
+    /** Keeps track of the uniqueIds we've seen recently */
+    private val history = RotatingSearchList<String>(historySize)
+    private var currentIterator: Iterator<T>? = null
+    private var resumeTimeMillis = -1L
+
+    override fun hasNext(): Boolean = true
+
+    override fun next(): T {
+        val it = currentIterator
+        if (it != null && it.hasNext()) {
+            return it.next()
+        }
+
+        val new = requestNew()
+        currentIterator = new
+        return new.next()
+    }
+
+    private fun requestNew(): Iterator<T> {
+        var newDataIterator: Iterator<T>? = null
+
+        while (newDataIterator == null) {
+            // Make sure to honor the backoff strategy
+            if (resumeTimeMillis > System.currentTimeMillis()) {
+                Thread.sleep(resumeTimeMillis - System.currentTimeMillis())
+            }
+
+            dataSource.restart()
+
+            val (new, old) = dataSource.next().partition { history.contains(it.uniqueId) }
+            old.forEach { history.add(it.uniqueId) }
+
+            // Calculate at which time to poll for new data
+            val backoffMillis = backoff.delayRequest(old.size, new.size + old.size)
+            require(backoffMillis >= 0) { "delayRequest must return a non-negative integer, was $backoffMillis" }
+            resumeTimeMillis = System.currentTimeMillis() + backoff.delayRequest(old.size, new.size + old.size)
+
+            // Yield in reverse order so that if more than one unseen item is present the older items are yielded first
+            if (old.isNotEmpty())
+                newDataIterator = old.asReversed().iterator()
+        }
+
+        return newDataIterator
+    }
+}

--- a/lib/src/test/kotlin/net/dean/jraw/test/unit/IntrospectiveTest.kt
+++ b/lib/src/test/kotlin/net/dean/jraw/test/unit/IntrospectiveTest.kt
@@ -15,43 +15,49 @@ These tests don't really test any functionality, but rather test some properties
  */
 
 class IntrospectiveTest : Spek({
+    val reflections = Reflections(ConfigurationBuilder()
+        .setUrls(ClasspathHelper.forPackage("net.dean.jraw"))
+        .setScanners(SubTypesScanner(false)))
+
+    fun assertAllImplement(superclass: Class<*>, pkg: String = "net.dean.jraw.models", manuallyExcluded: List<String> = listOf()) {
+        val testedExclusions = ArrayList(manuallyExcluded)
+
+        // It might be a better practice to combine all these filters into one using conjunctions, but this has
+        // better readability
+        val models = reflections.getSubTypesOf(Any::class.java)
+            // Only looking for non-internal models
+            .filter { it.`package`.name == pkg }
+            // We don't care about interfaces
+            .filter { !it.isInterface }
+            // AutoValue classes are taken care of as long as their parent classes are as well
+            .filter { !it.simpleName.matches(Regex("^\\\$*AutoValue_.+")) }
+            // We don't care about builders or special Kotlin-generated stuff
+            .filter { !it.name.endsWith("\$Builder") && !it.name.endsWith("\$DefaultImpls") }
+            // Find only the classes that don't implement Serializable
+            .filter { !it.kotlin.isSubclassOf(superclass.kotlin) }
+            // Ignore the classes that we've manually OK'd
+            .filter { !testedExclusions.remove(it.simpleName) }
+
+        if (models.isNotEmpty()) {
+            val limit = 10
+
+            // Show up to the first 10 classes
+            val csv = models.take(limit).joinToString(", ") { it.name }
+
+            // Also show how many more left
+            val more = if (limit >= models.size) "" else " (${models.size - limit} more)"
+
+            throw AssertionError("Expected ${models.size} classes to implement ${superclass.name}: $csv $more")
+        }
+
+        if (testedExclusions.isNotEmpty()) {
+            throw AssertionError("Class(es) was specified as manually excluded but never used: ${testedExclusions.joinToString(", ")}")
+        }
+    }
+
     describe("net.dean.jraw.models") {
         it("should all be serializable") {
-            val reflections = Reflections(ConfigurationBuilder()
-                .setUrls(ClasspathHelper.forPackage("net.dean.jraw"))
-                .setScanners(SubTypesScanner(false)))
-
-            val manuallyExcluded = listOf(
-                "net.dean.jraw.models.KindConstants"
-            )
-
-            // It might be a better practice to combine all these filters into one using conjunctions, but this has
-            // better readability
-            val models = reflections.getSubTypesOf(Any::class.java)
-                // Only looking for non-internal models
-                .filter { it.`package`.name == "net.dean.jraw.models" }
-                // We don't care about interfaces
-                .filter { !it.isInterface }
-                // AutoValue classes are taken care of as long as their parent classes are as well
-                .filter { !it.simpleName.matches(Regex("^\\\$*AutoValue_.+"))}
-                // We don't care about builders
-                .filter { !it.name.endsWith("\$Builder")}
-                // Find only the classes that don't implement Serializable
-                .filter { !it.kotlin.isSubclassOf(Serializable::class) }
-                // Ignore the classes that we've manually OK'd
-                .filter { it.name !in manuallyExcluded }
-
-            if (models.isNotEmpty()) {
-                val limit = 10
-
-                // Show up to the first 10 classes
-                val csv = models.take(limit).joinToString(", ") { it.name }
-
-                // Also show how many more left
-                val more = if (limit >= models.size) "" else " (${models.size - limit} more)"
-
-                throw AssertionError("Expected ${models.size} classes to implement Serializable: $csv $more")
-            }
+            assertAllImplement(Serializable::class.java, manuallyExcluded = listOf("KindConstants"))
         }
     }
 })

--- a/lib/src/test/kotlin/net/dean/jraw/test/unit/RotatingSearchListTest.kt
+++ b/lib/src/test/kotlin/net/dean/jraw/test/unit/RotatingSearchListTest.kt
@@ -1,0 +1,56 @@
+package net.dean.jraw.test.unit
+
+import com.winterbe.expekt.should
+import net.dean.jraw.pagination.RotatingSearchList
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+class RotatingSearchListTest : Spek({
+    lateinit var list: RotatingSearchList<Int>
+
+    beforeEachTest {
+        list = RotatingSearchList(capacity = 5)
+    }
+
+    describe("add") {
+        it("should add data to the front once the capacity is full") {
+            for (i in 0 until list.capacity) {
+                list.currentIndex.should.equal(i)
+                list.size.should.equal(i)
+
+                // add() should always return null here because we haven't had to overwrite any other data
+                list.add(i).should.be.`null`
+            }
+
+            // Filled the entire array, next index to be replaced should be the oldest data
+            list.size.should.equal(list.capacity)
+            list.currentIndex.should.equal(0)
+
+            // Make sure we've filled up the entire array
+            list.backingArray.toList().should.equal(listOf(0, 1, 2, 3, 4))
+
+            // Add one more element to the list, making sure it overwrites the beginning of the array
+            list.add(42).should.equal(0)
+            list.backingArray.toList().should.equal(listOf(42, 1, 2, 3, 4))
+        }
+    }
+
+    describe("contains") {
+        it("should report true only if the element is in the backing array") {
+            for (i in 0 until list.capacity) {
+                list.add(i)
+
+                for (j in 0..i) {
+                    list.contains(i).should.be.`true`
+                }
+            }
+
+            list.add(42)
+            list.contains(42).should.be.`true`
+
+            // We've overwritten 0 with 42, 0 should no longer be in the array
+            list.contains(0).should.be.`false`
+        }
+    }
+})

--- a/lib/src/test/kotlin/net/dean/jraw/test/unit/StreamTest.kt
+++ b/lib/src/test/kotlin/net/dean/jraw/test/unit/StreamTest.kt
@@ -1,0 +1,105 @@
+package net.dean.jraw.test.unit
+
+import com.winterbe.expekt.should
+import net.dean.jraw.models.Listing
+import net.dean.jraw.models.UniquelyIdentifiable
+import net.dean.jraw.pagination.BackoffStrategy
+import net.dean.jraw.pagination.ConstantBackoffStrategy
+import net.dean.jraw.pagination.RedditIterable
+import net.dean.jraw.pagination.Stream
+import net.dean.jraw.test.expectException
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.it
+
+class StreamTest : Spek({
+    lateinit var dataSource: FakePaginator
+    lateinit var stream: Stream<Foo>
+
+    beforeEachTest {
+        dataSource = FakePaginator()
+        stream = Stream(dataSource, PirateBackoffStrategy())
+    }
+
+    it("should yield the first page and then nothing after that") {
+        val initialAmount = 5
+        dataSource.addNewData(startId = 0, amount = initialAmount)
+
+        // Request the first page. There should only be `initialAmount` elements in the list once we call toList()
+        stream
+            .asSequence()
+            .take(initialAmount)
+            .map { it.uniqueId.toInt() }
+            .toList()
+            .should.equal((0 until initialAmount).toList())
+
+        expectException(NoMoreBootyException::class) {
+            stream.next()
+        }
+
+        val newStartId = 10
+        val newData = 3
+        dataSource.addNewData(startId = newStartId, amount = newData)
+
+        for (i in 0 until newData) {
+            stream
+                .next()
+                .uniqueId.toInt().should.equal(newStartId + i)
+        }
+    }
+
+    it("should throw an exception when the BackoffStrategy returns a negative integer") {
+        stream = Stream(dataSource, backoff = ConstantBackoffStrategy(-1L))
+        expectException(IllegalArgumentException::class) {
+            stream.next()
+        }
+    }
+})
+
+private class FakePaginator(val limit: Int = 5) : RedditIterable<Foo> {
+    override val current: Listing<Foo>? = null
+    override val pageNumber: Int get() = _pageNumber
+    private var _pageNumber: Int = 0
+    private val allData = mutableListOf<Foo>()
+
+    private var lastEnd: Int = -1
+
+    fun addNewData(startId: Int, amount: Int) {
+        for (i in startId until startId + amount) {
+            this.allData.add(0, Foo(i.toString()))
+        }
+    }
+
+    override fun next(): Listing<Foo> {
+        val endIndex = Math.min(lastEnd + 1 + limit, allData.size)
+        val next = Listing.create(pageNumber.toString(), allData.subList(lastEnd + 1, endIndex))
+        lastEnd = endIndex
+        return next
+    }
+
+    override fun restart() {
+        lastEnd = -1
+        _pageNumber = 0
+    }
+
+    override fun hasStarted(): Boolean = pageNumber == 0
+
+    // We don't care about these things here
+    override fun accumulate(maxPages: Int): List<Listing<Foo>> = throw NotImplementedError()
+    override fun accumulateMerged(maxPages: Int): List<Foo> = throw NotImplementedError()
+    override fun iterator(): Iterator<Listing<Foo>> = throw NotImplementedError()
+}
+
+private data class Foo(override val uniqueId: String) : UniquelyIdentifiable
+
+/** Throws an [NoMoreBootyException] if there are no new items. */
+private class PirateBackoffStrategy : BackoffStrategy {
+    override fun delayRequest(newItems: Int, totalItems: Int): Long {
+        if (newItems == 0)
+            throw NoMoreBootyException()
+
+        // No delay
+        return 0L
+    }
+}
+
+private class NoMoreBootyException : RuntimeException("no more booty in this here Stream")

--- a/lib/src/test/kotlin/net/dean/jraw/test/util.kt
+++ b/lib/src/test/kotlin/net/dean/jraw/test/util.kt
@@ -5,6 +5,7 @@ import net.dean.jraw.RateLimitException
 import net.dean.jraw.RedditClient
 import net.dean.jraw.http.*
 import net.dean.jraw.models.OAuthData
+import net.dean.jraw.models.UniquelyIdentifiable
 import net.dean.jraw.models.Votable
 import net.dean.jraw.pagination.Paginator
 import net.dean.jraw.test.TestConfig.userAgent
@@ -84,7 +85,7 @@ fun <T> expectDescendingScore(objects: List<T>, allowedMistakes: Int = 0) {
     }
 }
 
-fun <T> testPaginator(p: Paginator.Builder<T>, mustHaveContent: Boolean = true): List<List<T>> {
+fun <T : UniquelyIdentifiable> testPaginator(p: Paginator.Builder<T>, mustHaveContent: Boolean = true): List<List<T>> {
     // Primarily just make sure that requests don't fail
     val lists = p.build().accumulate(maxPages = 2)
 


### PR DESCRIPTION
Some minor changes:

 - There's a new interface called `UniquelyIdentifable` with one method: `String getUniqueId()`.
 - The upper bound for RedditIterable (and therefore Paginator) has been changed from Any (Object in Java) to UniquelyIdentifiable.
 - RedditIterable has a new method: `Stream stream(BackoffStrategy)`.

A Stream is just a subclass of Iterator. It continuously fetches new data as it arrives, or as quickly as its BackoffStrategy allows. Currently, the only BackoffStrategy is ConstantBackoffStrategy, which allows requests to be made at a certain rate.

Here's a practical example of using a Stream:

```kotlin
for (c in redditClient.subreddit("RocketLeague").comments().build().stream()) {
    // Do something with the newly-created comment
}
```