### PR TITLE
Added support for crossposting

### DIFF
--- a/lib/src/main/java/net/dean/jraw/models/SubmissionKind.java
+++ b/lib/src/main/java/net/dean/jraw/models/SubmissionKind.java
@@ -2,5 +2,6 @@ package net.dean.jraw.models;
 
 public enum SubmissionKind {
     LINK,
-    SELF
+    SELF,
+    CROSSPOST
 }


### PR DESCRIPTION
To support cross posting the SubmissionKind needed an additional datum to indicate cross posting. The content of the post is then interpreted as the crosspost full name.